### PR TITLE
Reduce flickering

### DIFF
--- a/src/Bar.cpp
+++ b/src/Bar.cpp
@@ -4,8 +4,8 @@ using namespace Codingfield::UI;
 
 void Bar::Draw() {
   if(IsHidden()) return;
-  if(isUpdated)
+  if(isInvalidated)
     M5.Lcd.fillRect(position.x, position.y, size.width, size.height, WHITE);
 
-  isUpdated = false;
+  isInvalidated = false;
 }

--- a/src/Button.cpp
+++ b/src/Button.cpp
@@ -26,7 +26,6 @@ void Codingfield::UI::Button::SetSelected(bool s) {
   if(isSelected != s) {
     wasSelected = isSelected;
     isSelected = s;
-    SetUpdateFlag();
   }
 }
 
@@ -37,7 +36,6 @@ void Codingfield::UI::Button::SetText(const std::string& t) {
     else
       this->oldText = this->text;
     this->text = t;
-    SetUpdateFlag();
   }
 }
 
@@ -48,14 +46,19 @@ void Codingfield::UI::Button::SetTitle(const std::string& t) {
     else
       oldTitle = title;
     title = t;
-    SetUpdateFlag();
   }
 }
 
 void Codingfield::UI::Button::Draw() {
-  if(IsHidden()) return;
+  if(IsHidden()){
+    return;
+  }
   if(true) {
-    bool forceUpdate = false;
+    bool forceUpdate = isInvalidated;
+    if(forceUpdate) {
+      Serial.println("FORCEUPDATE");
+
+    }
     int x = position.x + (size.width/2);
     int yText;
     int yTitle;
@@ -66,7 +69,7 @@ void Codingfield::UI::Button::Draw() {
       yTitle = position.y + ((size.height/3)*2);
     }
 
-    if(backgroundColorUpdated) {
+    if(backgroundColorUpdated || forceUpdate) {
       M5.Lcd.fillRect(position.x, position.y, size.width, size.height, backgroundColor);
       backgroundColorUpdated = false;
       forceUpdate = true;
@@ -96,7 +99,7 @@ void Codingfield::UI::Button::Draw() {
       oldTitle = title;
     }
 
-    if(wasSelected != isSelected) {
+    if(forceUpdate || (wasSelected != isSelected)) {
       if(isSelected) {
         M5.Lcd.drawRect(position.x, position.y, size.width, size.height, RED);
         M5.Lcd.drawRect(position.x+1, position.y+1, size.width-2, size.height-2, RED);
@@ -108,5 +111,5 @@ void Codingfield::UI::Button::Draw() {
       }
     }
   }
-  isUpdated = false;
+  isInvalidated = false;
 }

--- a/src/Button.cpp
+++ b/src/Button.cpp
@@ -14,6 +14,7 @@ Codingfield::UI::Button::Button(Widget* parent, Point position, Size size) : Wid
 }
 
 void Codingfield::UI::Button::SetBackgroundColor(Color c) {
+  backgroundColorUpdated = true;
   this->backgroundColor = c;
 }
 
@@ -23,6 +24,7 @@ void Codingfield::UI::Button::SetTextColor(Color c) {
 
 void Codingfield::UI::Button::SetSelected(bool s) {
   if(isSelected != s) {
+    wasSelected = isSelected;
     isSelected = s;
     SetUpdateFlag();
   }
@@ -30,6 +32,10 @@ void Codingfield::UI::Button::SetSelected(bool s) {
 
 void Codingfield::UI::Button::SetText(const std::string& t) {
   if(text != t) {
+    if(text.empty())
+      oldText = t;
+    else
+      this->oldText = this->text;
     this->text = t;
     SetUpdateFlag();
   }
@@ -37,6 +43,10 @@ void Codingfield::UI::Button::SetText(const std::string& t) {
 
 void Codingfield::UI::Button::SetTitle(const std::string& t) {
   if(title != t) {
+    if(title.empty())
+      oldTitle = t;
+    else
+      oldTitle = title;
     title = t;
     SetUpdateFlag();
   }
@@ -44,28 +54,58 @@ void Codingfield::UI::Button::SetTitle(const std::string& t) {
 
 void Codingfield::UI::Button::Draw() {
   if(IsHidden()) return;
-  if(isUpdated) {
-    M5.Lcd.setTextColor(textColor);
-
-    M5.Lcd.fillRect(position.x, position.y, size.width, size.height, backgroundColor);
-    M5.Lcd.setTextDatum(MC_DATUM);
-    M5.Lcd.setTextColor(textColor);
+  if(true) {
+    bool forceUpdate = false;
+    int x = position.x + (size.width/2);
+    int yText;
+    int yTitle;
     if(title.empty()) {
-      M5.Lcd.setFreeFont(FF22);
-      M5.Lcd.drawString(text.c_str(), position.x + (size.width/2), position.y + (size.height/2));
-      M5.Lcd.setFreeFont(FF21);
-    }
-    else {
-      M5.Lcd.setFreeFont(FF22);
-      M5.Lcd.drawString(text.c_str(), position.x + (size.width/2), position.y + (size.height/3));
-      M5.Lcd.setFreeFont(FF21);
-      M5.Lcd.drawString(title.c_str(), position.x + (size.width/2), position.y + ((size.height/3)*2));
+      yText = position.y + (size.height/2);
+    } else {
+      yText = position.y + (size.height/3);
+      yTitle = position.y + ((size.height/3)*2);
     }
 
-    if(isSelected) {
-      M5.Lcd.drawRect(position.x, position.y, size.width, size.height, RED);
-      M5.Lcd.drawRect(position.x+1, position.y+1, size.width-2, size.height-2, RED);
-      M5.Lcd.drawRect(position.x+2, position.y+2, size.width-4, size.height-4, RED);
+    if(backgroundColorUpdated) {
+      M5.Lcd.fillRect(position.x, position.y, size.width, size.height, backgroundColor);
+      backgroundColorUpdated = false;
+      forceUpdate = true;
+    }
+
+    if(forceUpdate || (oldText != text)) {
+      M5.Lcd.setTextDatum(MC_DATUM);
+      M5.Lcd.setTextColor(backgroundColor);
+
+      M5.Lcd.setFreeFont(FF22);
+      M5.Lcd.drawString(oldText.c_str(), x, yText);
+
+      M5.Lcd.setTextColor(textColor);
+      M5.Lcd.drawString(text.c_str(), x, yText);
+      oldText = text;
+    }
+
+    if(forceUpdate || (oldTitle != title)) {
+      M5.Lcd.setTextDatum(MC_DATUM);
+      M5.Lcd.setTextColor(backgroundColor);
+
+      M5.Lcd.setFreeFont(FF21);
+      M5.Lcd.drawString(oldTitle.c_str(), x, yTitle);
+
+      M5.Lcd.setTextColor(textColor);
+      M5.Lcd.drawString(title.c_str(), x, yTitle);
+      oldTitle = title;
+    }
+
+    if(wasSelected != isSelected) {
+      if(isSelected) {
+        M5.Lcd.drawRect(position.x, position.y, size.width, size.height, RED);
+        M5.Lcd.drawRect(position.x+1, position.y+1, size.width-2, size.height-2, RED);
+        M5.Lcd.drawRect(position.x+2, position.y+2, size.width-4, size.height-4, RED);
+      } else {
+        M5.Lcd.drawRect(position.x, position.y, size.width, size.height, backgroundColor);
+        M5.Lcd.drawRect(position.x + 1, position.y + 1, size.width - 2, size.height - 2, backgroundColor);
+        M5.Lcd.drawRect(position.x + 2, position.y + 2, size.width - 4, size.height - 4, backgroundColor);
+      }
     }
   }
   isUpdated = false;

--- a/src/Button.h
+++ b/src/Button.h
@@ -16,10 +16,13 @@ namespace Codingfield {
       void Draw() override;
     protected:
       Color backgroundColor = BLACK;
+      bool backgroundColorUpdated = true;
       Color textColor = BLACK;
       std::string text;
+      std::string oldText;
       std::string title;
-
+      std::string oldTitle;
+      bool wasSelected = false;
     };
   }
 }

--- a/src/ButtonInfoBar.cpp
+++ b/src/ButtonInfoBar.cpp
@@ -4,41 +4,58 @@ using namespace Codingfield::UI;
 
 void ButtonInfoBar::SetButtonAText(const std::string& t) {
   if(btnAText != t) {
+    oldBtnAText = btnAText;
     btnAText = t;
-    isUpdated = true;
   }
 }
 
 void ButtonInfoBar::SetButtonBText(const std::string& t) {
   if(btnBText != t) {
+    oldBtnBText = btnBText;
     btnBText = t;
-    isUpdated = true;
   }
 }
 
 void ButtonInfoBar::SetButtonCText(const std::string& t) {
   if(btnCText != t) {
+    oldBtnCText = btnCText;
     btnCText = t;
-    isUpdated = true;
   }
 }
 
 void ButtonInfoBar::Draw() {
   if(IsHidden()) return;
-  bool oldIsUpdated = isUpdated;
+  bool oldIsInvalidated = isInvalidated;
   Bar::Draw();
 
-  if(oldIsUpdated) {
-    M5.Lcd.setTextColor(BLACK);
-
+  if(oldIsInvalidated || (oldBtnAText != btnAText)) {
     M5.Lcd.setTextDatum(TC_DATUM);
+    M5.Lcd.setTextColor(color);
+    M5.Lcd.drawString(oldBtnAText.c_str(), (size.width/6), position.y + 5);
+    M5.Lcd.setTextColor(BLACK);
     M5.Lcd.drawString(btnAText.c_str(), (size.width/6), position.y + 5);
 
+    oldBtnAText = btnAText;
+  }
+
+  if(oldIsInvalidated || (oldBtnBText != btnBText)) {
     M5.Lcd.setTextDatum(TC_DATUM);
+    M5.Lcd.setTextColor(color);
+    M5.Lcd.drawString(oldBtnBText.c_str(), size.width/2, position.y + 5);
+    M5.Lcd.setTextColor(BLACK);
     M5.Lcd.drawString(btnBText.c_str(), size.width/2, position.y + 5);
 
-    M5.Lcd.setTextDatum(TC_DATUM);
-    M5.Lcd.drawString(btnCText.c_str(), ((size.width/3)*2) + (size.width/6), position.y + 5);
+    oldBtnBText = btnBText;
   }
-  isUpdated = false;
+
+  if(oldIsInvalidated || (oldBtnCText != btnCText)) {
+    M5.Lcd.setTextDatum(TC_DATUM);
+    M5.Lcd.setTextColor(color);
+    M5.Lcd.drawString(oldBtnCText.c_str(), ((size.width/3)*2) + (size.width/6), position.y + 5);
+    M5.Lcd.setTextColor(BLACK);
+    M5.Lcd.drawString(btnCText.c_str(), ((size.width/3)*2) + (size.width/6), position.y + 5);
+
+    oldBtnCText = btnCText;
+  }
+  isInvalidated = false;
 }

--- a/src/ButtonInfoBar.h
+++ b/src/ButtonInfoBar.h
@@ -15,8 +15,11 @@ namespace Codingfield {
     private:
       Color color = WHITE;
       std::string btnAText;
+      std::string oldBtnAText;
       std::string btnBText;
+      std::string oldBtnBText;
       std::string btnCText;
+      std::string oldBtnCText;
     };
   }
 }

--- a/src/Screen.cpp
+++ b/src/Screen.cpp
@@ -8,11 +8,11 @@ void Screen::Draw() {
   M5.Lcd.setTextSize(1);
 
   if(IsHidden()) return;
-  if(isUpdated)
+  if(isInvalidated)
     M5.Lcd.fillScreen(color);
 
   for(Widget* w : children)
     w->Draw();
 
-  isUpdated = false;
+  isInvalidated = false;
 }

--- a/src/StatusBar.cpp
+++ b/src/StatusBar.cpp
@@ -9,40 +9,31 @@ extern const uint8_t image_data_wifi3[];
 
 void StatusBar::SetWifiStatus(const StatusBar::WifiStatuses status) {
   if(wifiStatus != status) {
+    oldWifiStatus = wifiStatus;
     wifiStatus = status;
-    SetUpdateFlag();
   }
 }
 
 void StatusBar::SetUptime(const uint32_t t) {
   if(uptime != t) {
+    oldUptime = uptime;
     uptime = t;
-    SetUpdateFlag();
   }
 }
 
 void StatusBar::SetDateTime(const std::string& t) {
   if(dateTime != t) {
+    oldDateTime = dateTime;
     dateTime = t;
-    SetUpdateFlag();
   }
 }
 
 void StatusBar::Draw() {
   if(IsHidden()) return;
-  bool oldIsUpdated = isUpdated;
+  bool wasInvalidated = isInvalidated;
   Bar::Draw();
 
-  if(oldIsUpdated) {
-    M5.Lcd.setTextColor(BLACK);
-
-    M5.Lcd.setTextDatum(TL_DATUM);
-    String s = String("UP:") + String(uptime) + String("h");
-    M5.Lcd.drawString(s.c_str(), 1, 5);
-
-    M5.Lcd.setTextDatum(TC_DATUM);
-    M5.Lcd.drawString(dateTime.c_str(), 160, 5);
-
+  if(wasInvalidated || (wifiStatus != oldWifiStatus)) {
     const uint8_t* wifibmp = image_data_wifi0;
     switch(wifiStatus) {
       case WifiStatuses::Weak: wifibmp = image_data_wifi1; break;
@@ -56,6 +47,34 @@ void StatusBar::Draw() {
 
     M5.Lcd.setBitmapColor(BLACK, color);
     M5.Lcd.pushImage(295, 0, 25, 25, const_cast<uint8_t*>(wifibmp), false);
+
+    oldWifiStatus = wifiStatus;
   }
-  isUpdated = false;
+
+  if(wasInvalidated || (oldDateTime != dateTime)) {
+    M5.Lcd.setTextDatum(TC_DATUM);
+
+    M5.Lcd.setTextColor(color);
+    M5.Lcd.drawString(oldDateTime.c_str(), 160, 5);
+
+    M5.Lcd.setTextColor(BLACK);
+    M5.Lcd.drawString(dateTime.c_str(), 160, 5);
+
+    oldDateTime = dateTime;
+  }
+
+  if(wasInvalidated || (oldUptime != uptime)) {
+    M5.Lcd.setTextDatum(TL_DATUM);
+
+    M5.Lcd.setTextColor(color);
+    String s = String("UP:") + String(oldUptime) + String("h");
+    M5.Lcd.drawString(s.c_str(), 1, 5);
+
+    M5.Lcd.setTextColor(BLACK);
+    s = String("UP:") + String(uptime) + String("h");
+    M5.Lcd.drawString(s.c_str(), 1, 5);
+
+    oldUptime = uptime;
+  }
+  isInvalidated = false;
 }

--- a/src/StatusBar.h
+++ b/src/StatusBar.h
@@ -6,7 +6,7 @@ namespace Codingfield {
   namespace UI {
     class StatusBar : public Bar {
     public:
-      enum class WifiStatuses {No_signal, Weak, Medium, Full};
+      enum class WifiStatuses {Unknown, No_signal, Weak, Medium, Full};
       StatusBar() : Bar() {}
       StatusBar(Widget* parent, Point position, int32_t height) : Bar(parent, position, height) {}
       void Draw() override;
@@ -16,9 +16,12 @@ namespace Codingfield {
 
     private:
       Color color = WHITE;
-      WifiStatuses wifiStatus;
-      uint32_t uptime;
+      WifiStatuses wifiStatus = WifiStatuses::No_signal;
+      WifiStatuses oldWifiStatus = WifiStatuses::Unknown;
+      uint32_t uptime = 0;
+      uint32_t oldUptime = UINT32_MAX;
       std::string dateTime;
+      std::string oldDateTime;
     };
   }
 }

--- a/src/UpDownButton.cpp
+++ b/src/UpDownButton.cpp
@@ -9,8 +9,10 @@ UpDownButton::UpDownButton(Widget* parent) : Button(parent) {
 void UpDownButton::Draw() {
   if(IsHidden()) return;
 
-  if(isUpdated) {
-    Button::Draw();
+  bool wasInvalidated = isInvalidated;
+  Button::Draw();
+
+  if(wasInvalidated) {
     if(controlsEnabled) {
       M5.Lcd.setTextDatum(MC_DATUM);
       M5.Lcd.setTextColor(textColor);
@@ -18,8 +20,6 @@ void UpDownButton::Draw() {
       M5.Lcd.drawString("+", position.x + (size.width - (size.width/6)), position.y + (size.height/2));
     }
   }
-
-  isUpdated = false;
 }
 
 void UpDownButton::EnableControls()  {
@@ -32,29 +32,25 @@ void UpDownButton::DisableControls() {
 
 void UpDownButton::OnButtonAPressed() {
   if(upCallback != nullptr) {
-    if(downCallback(this))
-      SetUpdateFlag();
+    downCallback(this);
   }
 }
 
 void UpDownButton::OnButtonBPressed() {
   if(applyCallback != nullptr) {
-    if(applyCallback(this))
-      SetUpdateFlag();
+    applyCallback(this);
   }
 }
 
 void UpDownButton::OnButtonBLongPush() {
   if(cancelCallback != nullptr) {
-    if(cancelCallback(this))
-      SetUpdateFlag();
+    cancelCallback(this);
   }
 }
 
 void UpDownButton::OnButtonCPressed() {
   if(upCallback != nullptr) {
-    if(upCallback(this))
-      SetUpdateFlag();
+    upCallback(this);
   }
 }
 

--- a/src/Widget.cpp
+++ b/src/Widget.cpp
@@ -11,11 +11,11 @@ Widget::Widget(Widget* parent, Point position, Size size) :  parent{parent}, pos
     parent->AddChild(this);
 }
 
-void Widget::SetUpdateFlag() {
+void Widget::Invalidate() {
   for(auto c : children) {
-    c->SetUpdateFlag();
+    c->Invalidate();
   }
-  isUpdated = true;
+  isInvalidated = true;
 }
 
 void Widget::SetSize(const Size& s) {

--- a/src/Widget.h
+++ b/src/Widget.h
@@ -28,10 +28,20 @@ namespace Codingfield {
       void SetPosition(const Point& p);
 
       /* The widget will be visible (drawn) the next time Draw() will be called */
-      void Show() { SetUpdateFlag(); isVisible = true; }
+      void Show() {
+        if (!isVisible) {
+          Invalidate();
+          isVisible = true;
+        }
+      }
 
       /* The widget will not be visible (not drawn) the next time Draw() will be called */
-      void Hide() { SetUpdateFlag(); isVisible = false; }
+      void Hide() {
+        if (isVisible) {
+          Invalidate();
+          isVisible = false;
+        }
+      }
 
       bool IsVisible() const { return isVisible;}
       bool IsHidden() const { return !isVisible;}
@@ -60,20 +70,20 @@ namespace Codingfield {
       /* Enables/disables controls on the button */
       virtual void EnableControls() {}
       virtual void DisableControls() {}
+      void Invalidate();
 
     protected:
       virtual void OnSizeUpdated() { }
       virtual void OnPositionUpdated() { }
-      void SetUpdateFlag();
 
       Point position;
       Size size;
       Widget* parent = nullptr;
       std::vector<Widget*> children;
       bool isSelected = false;
-      bool isUpdated = true;
       bool isVisible = true;
       bool isEditable = false;
+      bool isInvalidated = true;
     };
   }
 }

--- a/src/WidgetMosaic.cpp
+++ b/src/WidgetMosaic.cpp
@@ -13,19 +13,14 @@ WidgetMosaic::WidgetMosaic(int32_t nbColumns, int32_t nbRows) : WidgetMosaic(nul
 
 void WidgetMosaic::Draw() {
   if(IsHidden()) return;
-  if(isUpdated) {
+  if(isInvalidated) {
     M5.Lcd.fillRect(position.x, position.y, size.width, size.height, BLACK);
   }
 
-  if(!zoomOnSelected) {
-    for(Widget* w : children)
-      w->Draw();
-  }
-  else {
-    selectedWidget->Draw();
-  }
+  for(Widget* w : children)
+    w->Draw();
 
-  isUpdated = false;
+  isInvalidated = false;
 }
 
 void WidgetMosaic::AddChild(Widget* widget) {
@@ -36,7 +31,7 @@ void WidgetMosaic::AddChild(Widget* widget) {
 
   int32_t position = ((children.size()-1) % (nbRows*nbColumns));
   widget->SetPosition(ComputeWidgetPosition(widgetSize, position));
-  SetUpdateFlag();
+  Invalidate();
 }
 
 const Widget* WidgetMosaic::GetSelected() const {
@@ -46,10 +41,15 @@ const Widget* WidgetMosaic::GetSelected() const {
 void WidgetMosaic::ZoomOnSelected(bool enabled) {
   bool oldValue = zoomOnSelected;
   if(selectedWidget != nullptr && enabled) {
+    for(auto* w : children)
+      w->Hide();
+
     zoomOnSelected = true;
     Size widgetSize = ComputeWidgetSize(1,1);
     selectedWidget->SetSize(widgetSize);
     selectedWidget->SetPosition(ComputeWidgetPosition(widgetSize, 0));
+    selectedWidget->Show();
+    selectedWidget->Invalidate();
     if(selectedWidget->IsEditable()) {
       selectedWidget->EnableControls();
     }
@@ -61,6 +61,7 @@ void WidgetMosaic::ZoomOnSelected(bool enabled) {
       Size widgetSize = ComputeWidgetSize();
       widget->SetSize(widgetSize);
       widget->SetPosition(ComputeWidgetPosition(widgetSize, index));
+      widget->Show();
       if(selectedWidget->IsEditable()) {
         selectedWidget->DisableControls();
       }
@@ -69,7 +70,7 @@ void WidgetMosaic::ZoomOnSelected(bool enabled) {
 
   if(oldValue != zoomOnSelected) {
     zoomOnSelectedCallback(selectedWidget, zoomOnSelected);
-    SetUpdateFlag();
+    Invalidate();
   }
 }
 


### PR DESCRIPTION
New redraw strategy : instead of fully redraw the widget when its isUpdated flag is set, the widget checks its content on every Draw() and refresh only what's necessary.
Special care is given to texts. Previously, the whole widget was redrawn, and the text printed on top. Now, it is not necessary to redraw the background : the text is first redraw with the background color and then, the new text is drawn with the text color.

All in all, normal refreshes are faster (3 - 10x), and flickering is less visible.