### PR TITLE
Declaration order changed in Widget.h and WidgetMosaic.h

### DIFF
--- a/src/Widget.h
+++ b/src/Widget.h
@@ -76,9 +76,9 @@ namespace Codingfield {
       virtual void OnSizeUpdated() { }
       virtual void OnPositionUpdated() { }
 
+      Widget* parent = nullptr;
       Point position;
       Size size;
-      Widget* parent = nullptr;
       std::vector<Widget*> children;
       bool isSelected = false;
       bool isVisible = true;

--- a/src/WidgetMosaic.h
+++ b/src/WidgetMosaic.h
@@ -21,8 +21,8 @@ namespace Codingfield {
     private:
       int32_t indexSelected = 0;
       int32_t border = 5;
-      int32_t nbRows;
       int32_t nbColumns;
+      int32_t nbRows;
 
       Size ComputeWidgetSize();
       Size ComputeWidgetSize(int32_t nbColumns, int32_t nbRows);


### PR DESCRIPTION
Declaration order changed in Widget.h and WidgetMosaic.h to fix compilation error [-Werror=reorder]